### PR TITLE
Adding appveyor badge

### DIFF
--- a/status.html
+++ b/status.html
@@ -17,6 +17,11 @@
           </a>
         </td>
         <td>
+          <a href="https://ci.appveyor.com/project/{{user}}/{{repo}}?branch=master">
+            <img src="https://ci.appveyor.com/api/projects/status/github/{{user}}/{{repo}}?branch=master&svg=true">
+          </a>
+        </td>
+        <td>
           <a href="https://coveralls.io/r/{{user}}/{{repo}}?branch=master">
             <img src="https://coveralls.io/repos/{{user}}/{{repo}}/badge.svg?branch=master">
           </a>


### PR DESCRIPTION
Somehow the dashboard generation doesn't work for me locally, so couldn't test how this looks like. It is quite possible to have problems with the badges of projects that don't have appveyor enabled.