### PR TITLE
Fix links to pypi badges and pages

### DIFF
--- a/template.html
+++ b/template.html
@@ -76,8 +76,8 @@
           {% endif %}
           {% if 'pypi' in package.badges %}
           <td align='left'>
-            <a href="https://pypi.python.org/pypi/{{ package.pypi_name }}">
-              <img src="https://pypip.in/v/{{ package.pypi_name }}/badge.svg">
+            <a href="https://pypi.org/project/{{ package.pypi_name }}">
+              <img src="https://img.shields.io/pypi/v/{{ package.pypi_name }}.svg">
             </a>
           </td>
           {% else %}


### PR DESCRIPTION
The badges for pypi were being generated from an outdated location and the links to pypi itself were to the old pypi not the new one. This fixes both issues and produces a correct-looking status.html locally.