### PR TITLE
MNT: Replace master with main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ script:
   - cp deploy/* .
   - git add status.html style.css
   - git commit -m "Updated dashboard" || true
-  - if [[ $TRAVIS_EVENT_TYPE != pull_request && $TRAVIS_BRANCH == master ]]; then git push -q -f https://$GITHUB_USER:$GITHUB_API_KEY@github.com/$TRAVIS_REPO_SLUG gh-pages; fi
+  - if [[ $TRAVIS_EVENT_TYPE != pull_request && $TRAVIS_BRANCH == main ]]; then git push -q -f https://$GITHUB_USER:$GITHUB_API_KEY@github.com/$TRAVIS_REPO_SLUG gh-pages; fi

--- a/template.html
+++ b/template.html
@@ -26,7 +26,7 @@
           {% if 'travis' in package.badges %}
           <td align='left'>
             <a href="https://travis-ci.org/{{ package.travis_project }}">
-              <img src="https://travis-ci.org/{{ package.travis_project }}.svg?branch=master">
+              <img src="https://travis-ci.org/{{ package.travis_project }}.svg?branch=main">
             </a>
           </td>
           {% else %}
@@ -43,8 +43,8 @@
           {% endif %}
           {% if 'appveyor' in package.badges %}
           <td align='left'>
-            <a href="https://ci.appveyor.com/project/{{ package.appveyor_project }}?branch=master">
-              <img src="https://img.shields.io/appveyor/ci/{{ package.appveyor_project }}/master.svg">
+            <a href="https://ci.appveyor.com/project/{{ package.appveyor_project }}?branch=main">
+              <img src="https://img.shields.io/appveyor/ci/{{ package.appveyor_project }}/main.svg">
             </a>
           </td>
           {% else %}
@@ -52,14 +52,14 @@
           {% endif %}
           {% if 'coveralls' in package.badges %}
           <td align='left'>
-            <a href="https://coveralls.io/r/{{ package.repo }}?branch=master">
-              <img src="https://coveralls.io/repos/{{ package.repo }}/badge.svg?branch=master">
+            <a href="https://coveralls.io/r/{{ package.repo }}?branch=main">
+              <img src="https://coveralls.io/repos/{{ package.repo }}/badge.svg?branch=main">
             </a>
           </td>
           {% elif 'codecov' in package.badges %}
           <td align='left'>
-            <a href="https://codecov.io/gh/{{ package.repo }}?branch=master">
-              <img src="https://codecov.io/gh/{{ package.repo }}/branch/master/graph/badge.svg">
+            <a href="https://codecov.io/gh/{{ package.repo }}?branch=main">
+              <img src="https://codecov.io/gh/{{ package.repo }}/branch/main/graph/badge.svg">
             </a>
           </td>
           {% else %}


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is part of #30.